### PR TITLE
Dump BTreeFolder2 as a Folder

### DIFF
--- a/Products/FSDump/Dumper.py
+++ b/Products/FSDump/Dumper.py
@@ -582,6 +582,7 @@ class Dumper( SimpleItem ):
     _handlers = { 'DTML Method'     : _dumpDTMLMethod
                 , 'DTML Document'   : _dumpDTMLDocument
                 , 'Folder'          : _dumpFolder
+                , 'BTreeFolder2'    : _dumpFolder
                 , 'External Method' : _dumpExternalMethod
                 , 'File'            : _dumpFileOrImage
                 , 'Image'           : _dumpFileOrImage


### PR DESCRIPTION
Just associate Folder handler also to BTreeFolder2. Useful for older zope installs. 